### PR TITLE
Default processor title from fields name

### DIFF
--- a/src/me/drton/flightplot/FlightPlot.java
+++ b/src/me/drton/flightplot/FlightPlot.java
@@ -163,7 +163,7 @@ public class FlightPlot {
                 }
                 PlotProcessor processor = new Simple();
                 processor.getParameters().put("Fields", fieldsValue.toString());
-                processor.setTitle("New");
+                processor.setTitle(fieldsValue.toString());
                 processorsListModel.addElement(processor);
                 processorsList.setSelectedValue(processor, true);
                 processorsList.repaint();


### PR DESCRIPTION
Just wondering if it would be more handy to have default processors title set to fields name when you choose a new plot from fields list dialog.
